### PR TITLE
Register: quiz.is-a.software

### DIFF
--- a/domains/quiz.json
+++ b/domains/quiz.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "github": "zaselalk"
+  },
+  "record": {
+    "CNAME": "zaselalk.github.io/JS-QuizApp"
+  },
+  "proxy": false
+}


### PR DESCRIPTION
This pull request adds a new domain configuration for a quiz application. The configuration specifies the owner, sets up a CNAME record for deployment, and disables proxying.

Domain configuration:

* [`domains/quiz.json`](diffhunk://#diff-394a4f70ad1e513b0dc61a7d192d863a499bf211d9de8ae78e761a22f8e2ee42R1-R9): Added a new domain configuration file with owner information, a CNAME record pointing to `zaselalk.github.io/JS-QuizApp`, and proxying disabled.